### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/prod_deployer.yml
+++ b/.github/workflows/prod_deployer.yml
@@ -54,7 +54,7 @@ jobs:
       uses: "WyriHaximus/github-action-get-previous-tag@master"
     - name: Deploy to Dockerhub
       if: env.HAS_CHANGES == 'true'
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: matisotee/freestyle-jury-api
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/qa_deployer.yml
+++ b/.github/workflows/qa_deployer.yml
@@ -51,7 +51,7 @@ jobs:
       id: previoustag
       uses: "WyriHaximus/github-action-get-previous-tag@master"
     - name: Deploy to Dockerhub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: matisotee/freestyle-jury-api-qa
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore